### PR TITLE
correct number of supported colours for 12.48in waveshare B

### DIFF
--- a/components/CalEPD/include/wave12i48BR.h
+++ b/components/CalEPD/include/wave12i48BR.h
@@ -36,7 +36,7 @@ class Wave12I48RB : public Epd
   public:
    
     Wave12I48RB(Epd4Spi& IO);
-    bool colors_supported = 1;
+    bool colors_supported = 3;
     
     void drawPixel(int16_t x, int16_t y, uint16_t color);  // Override GFX own drawPixel method
     


### PR DESCRIPTION
otherwise cale.es BMPs are rendered black and white