### PR TITLE
Esp32s2 waveshare 5.6inch not responding with abnormal color sequence 

### DIFF
--- a/components/CalEPD/CMakeLists.txt
+++ b/components/CalEPD/CMakeLists.txt
@@ -1,41 +1,41 @@
 # Add only the display srcs you are going to use if you want to keep compiled srcs to a minimum:
 set(srcs 
-    "models/wave12i48.cpp"
-    "models/gdew075HD.cpp"
-    "models/gdew075T7.cpp"
-    "models/gdew075T7Grays.cpp"
-    "models/gdew075T8.cpp"
-    "models/gdew0583t7.cpp"
-    "models/gdew042t2.cpp"
-    "models/gdew027w3.cpp"
-    "models/wave12i48.cpp"
+    # "models/wave12i48.cpp"
+    # "models/gdew075HD.cpp"
+    # "models/gdew075T7.cpp"
+    # "models/gdew075T7Grays.cpp"
+    # "models/gdew075T8.cpp"
+    # "models/gdew0583t7.cpp"
+    # "models/gdew042t2.cpp"
+    # "models/gdew027w3.cpp"
+    # "models/wave12i48.cpp"
     # Touch model, please also enable FT6X36-IDF in the REQUIRE section
     #"models/gdew027w3T.cpp"
-    "models/gdew0213i5f.cpp"
-    "models/gdeh0213b73.cpp"
-    "models/gdep015OC1.cpp"
-    "models/gdeh0154d67.cpp"
-    "models/heltec0151.cpp"
+    # "models/gdew0213i5f.cpp"
+    # "models/gdeh0213b73.cpp"
+    # "models/gdep015OC1.cpp"
+    # "models/gdeh0154d67.cpp"
+    # "models/heltec0151.cpp"
     
     # 3 colors Goodisplay
-    "models/color/gdeh0154z90.cpp"
-    "models/color/gdew0583z21.cpp"
-    "models/color/gdew075z09.cpp"
-    "models/color/gdew075c64.cpp"
-    "models/color/gdeh042Z96.cpp"
-    "models/color/gdeh042Z21.cpp"
+    # "models/color/gdeh0154z90.cpp"
+    # "models/color/gdew0583z21.cpp"
+    # "models/color/gdew075z09.cpp"
+    # "models/color/gdew075c64.cpp"
+    # "models/color/gdeh042Z96.cpp"
+    # "models/color/gdeh042Z21.cpp"
     #"models/color/wave12i48BR.cpp"
 
     # 7 colors Waveshare
-    "models/color/wave4i7Color.cpp"
+    # "models/color/wave4i7Color.cpp"
     "models/color/wave5i7Color.cpp"
 
     # Plasticlogic.com Flex epaper models:
-    "models/plasticlogic/epdspi2cs.cpp"
-    "models/plasticlogic/plasticlogic.cpp"
-    "models/plasticlogic/plasticlogic011.cpp"
-    "models/plasticlogic/plasticlogic014.cpp"
-    "models/plasticlogic/plasticlogic021.cpp"
+    # "models/plasticlogic/epdspi2cs.cpp"
+    # "models/plasticlogic/plasticlogic.cpp"
+    # "models/plasticlogic/plasticlogic011.cpp"
+    # "models/plasticlogic/plasticlogic014.cpp"
+    # "models/plasticlogic/plasticlogic021.cpp"
     # Not-tested (never had one)
     #"models/plasticlogic/plasticlogic031.cpp"
 
@@ -48,21 +48,21 @@ set(srcs
     #"models/parallel/ED060XCN.cpp" # pending to be added
 
     # Pending for more testing:
-    "models/gdeh0213b73.cpp"
+    # "models/gdeh0213b73.cpp"
 
     # Common base classes
     "epd.cpp"
     "epd7color.cpp"
     "epdspi.cpp"
-    "epd4spi.cpp"
+    # "epd4spi.cpp"
     )
 
 # If the project does not use a touch display component FT6X36-IDF can be removed or #commented
 idf_component_register(SRCS ${srcs}      
                     REQUIRES "Adafruit-GFX"
-                    REQUIRES "FT6X36-IDF"
+                    # REQUIRES "FT6X36-IDF"
                     # Uncomment for parallel epapers:
-                    REQUIRES "epdiy"
+                    # REQUIRES "epdiy"
                     INCLUDE_DIRS "include"
 )
 

--- a/components/CalEPD/include/color/wave5i7Color.h
+++ b/components/CalEPD/include/color/wave5i7Color.h
@@ -36,7 +36,8 @@ class Wave5i7Color : public Epd7Color
   private:
     EpdSpi& IO;
 
-    uint8_t _buffer[WAVE5I7COLOR_BUFFER_SIZE];
+    // uint8_t _buffer[WAVE5I7COLOR_BUFFER_SIZE];
+    uint8_t *_buffer;
 
     bool _initial = true;
     void _wakeUp();

--- a/components/CalEPD/include/color/wave5i7Color.h
+++ b/components/CalEPD/include/color/wave5i7Color.h
@@ -36,7 +36,6 @@ class Wave5i7Color : public Epd7Color
   private:
     EpdSpi& IO;
 
-    // uint8_t _buffer[WAVE5I7COLOR_BUFFER_SIZE];
     uint8_t *_buffer;
 
     bool _initial = true;

--- a/components/CalEPD/models/color/wave5i7Color.cpp
+++ b/components/CalEPD/models/color/wave5i7Color.cpp
@@ -33,9 +33,9 @@ void Wave5i7Color::fillScreen(uint16_t color)
 {
   uint8_t pv = _color7(color);
   uint8_t pv2 = pv | pv << 4;
-  for (uint32_t x = 0; x < sizeof(_buffer); x++)
+  for (uint32_t x = 0; x <WAVE5I7COLOR_BUFFER_SIZE; x++)
   {
-    _buffer[x] = pv2;
+    *(_buffer + x)= pv2;
   }
 
   if (debug_enabled) printf("fillScreen(%x) black/red _buffer len:%d\n", color, sizeof(_buffer));
@@ -110,12 +110,13 @@ void Wave5i7Color::update()
   if (spi_optimized) {
     uint32_t i = 0;
     uint16_t xLineBytes = WAVE5I7COLOR_WIDTH/2;
+    // uint8_t *x1buf;
     uint8_t x1buf[xLineBytes];
     for (uint16_t y = 1; y <= WAVE5I7COLOR_HEIGHT; y++)
     {
       for (uint16_t x = 1; x <= xLineBytes; x++)
       {
-        uint8_t data = i < sizeof(_buffer) ? _buffer[i] : 0x33;
+        uint8_t data = i < WAVE5I7COLOR_BUFFER_SIZE ? *(_buffer + i) : 0x33;
         x1buf[x - 1] = data;
         if (x == xLineBytes)
         { // Flush the X line buffer to SPI
@@ -131,7 +132,7 @@ void Wave5i7Color::update()
 
   } else {
     for (uint32_t i = 0; i < sizeof(_buffer); i++) {
-      IO.data(_buffer[i]);
+      IO.data(*(_buffer + i));
     }
   }
   
@@ -223,6 +224,6 @@ void Wave5i7Color::drawPixel(int16_t x, int16_t y, uint16_t color) {
   uint32_t i = x / 2 + uint32_t(y) * (WAVE5I7COLOR_WIDTH / 2);
   uint8_t pv = _color7(color);
       
-  if (x & 1) _buffer[i] = (_buffer[i] & 0xF0) | pv;
-    else _buffer[i] = (_buffer[i] & 0x0F) | (pv << 4);
+  if (x & 1) *(_buffer + i) = (*(_buffer + i) & 0xF0) | pv;
+    else *(_buffer +i) = (*(_buffer + i) & 0x0F) | (pv << 4);
 }

--- a/components/CalEPD/models/color/wave5i7Color.cpp
+++ b/components/CalEPD/models/color/wave5i7Color.cpp
@@ -13,6 +13,7 @@ Wave5i7Color::Wave5i7Color(EpdSpi& dio):
 {
   printf("Wave5i7Color() constructor injects IO and extends Adafruit_GFX(%d,%d)\n",
   WAVE5I7COLOR_WIDTH, WAVE5I7COLOR_HEIGHT);  
+  _buffer= (uint8_t *)malloc(WAVE5I7COLOR_BUFFER_SIZE); 
 }
 
 //Initialize the display

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,7 +1,7 @@
 idf_component_register(
     # CALE official ESP-IDF Firmware
     
-    SRCS "cale.cpp"
+    # SRCS "cale.cpp"
     #SRCS "cale-7-color.cpp"
 
     # SRCS "demos/cale-sensor.cpp"
@@ -24,7 +24,7 @@ idf_component_register(
     #SRCS "demos/demo-fonts.cpp"
 
     # Demo to print 7 colors in Waveshare Acep epapers
-    #SRCS "demos/demo-7-colors.cpp"
+    SRCS "demos/demo-7-colors.cpp"
 
     # Demo only for plasticlogic.com epapers:
     #SRCS "demos/plasticlogic/demo-epaper-plasticlogic.cpp"


### PR DESCRIPTION
Hi everyone, I have been testing your library with esp32s2, using the S2 sdkconfig [file](https://github.com/martinberlin/cale-idf/blob/master/config-examples/sdkconfig_S2) but I'm getting as a result this color sequence that is displayed in the video, my code is fairly the same as in the demo, just commented no necessary files, and only using Adafruit submodule, can be seen in PR, also attached a logic analyzer trace, of what is currently happening. which seems ok to me, any help appreciated. 


and my idf version is

```
idf.py --version
ESP-IDF v4.4.2-378-g9269a536ac
```

https://user-images.githubusercontent.com/838303/193659812-afaddac9-9af2-4af5-8bb0-f22d5d61f25c.mp4

Logic analizer trace

![LA2](https://user-images.githubusercontent.com/838303/193659909-a8ad03b9-7da1-4581-9acc-21206ba71f31.png)
