### PR TITLE
fix: support for esp32s2

### DIFF
--- a/components/CalEPD/Kconfig.projbuild
+++ b/components/CalEPD/Kconfig.projbuild
@@ -31,7 +31,7 @@ menu "Display Configuration"
     
     config EINK_SPI_CS2
         int "EPD SPI: GPIO for Chip Select2"
-        range -1 34
+        range -1 48
         default 4
     config EINK_SPI_MISO
         int "EPD SPI: GPIO for MISO"
@@ -44,52 +44,52 @@ menu "Display Configuration"
     comment "| M1 | S1 |"
     config EINK_SPI_M1_CS
         int "* CS M1"
-        range 0 23
+        range 0 48
         default 23
     config EINK_SPI_S1_CS
         int "* CS S1"
-        range 0 23
+        range 0 48
         default 22
     config EINK_SPI_M2_CS
         int "* CS M2 do not use 16-17 when using PSRAM"
-        range 0 27
+        range 0 48
         default 16
     config EINK_SPI_S2_CS
         int "* CS S2"
-        range 0 23
+        range 0 48
         default 19
 
     config EINK_SPI_M1_BUSY
         int "* BUSY M1"
-        range 0 32
+        range 0 48
         default 32
     config EINK_SPI_S1_BUSY
         int "* BUSY S1"
-        range 0 32
+        range 0 48
         default 26
     config EINK_SPI_M2_BUSY
         int "* BUSY M2"
-        range 0 32
+        range 0 48
         default 18
     config EINK_SPI_S2_BUSY
         int "* BUSY S2"
-        range 0 32
+        range 0 48
         default 4
 
     config EINK_M1S1_DC
         int "* M1S1_DC: M1 & S1 share DC & RST"
-        range 0 25
+        range 0 48
         default 25
     config EINK_M2S2_DC
         int "* M2S2_DC do not use 16-17 when using PSRAM"
-        range 0 27
+        range 0 48
         default 17
     config EINK_M1S1_RST
         int "* M1S1_RST"
-        range 0 33
+        range 0 48
         default 33
     config EINK_M2S2_RST
         int "* M2S2_RST"
-        range 0 33
+        range 0 48
         default 5
 endmenu


### PR DESCRIPTION
A couple of small changes:
 - Increased max gpio values for 4 spi displays (to 48)
 - Fixed the "uint not declared" compile error in https://github.com/martinberlin/cale-idf/issues/103 (but not the SPI3 thing as I don't have an esp32c3)